### PR TITLE
Update guide_aires_securite.cup  : toponymie

### DIFF
--- a/guide_aires_securite.cup
+++ b/guide_aires_securite.cup
@@ -85,11 +85,11 @@ name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc,userdata,pics
 "316 Domaine de Malcor",316,FR,4428.500N,00606.233E,620.0m,3,270,250.0m,,,"270/90 Prairie. {normal}",,"316_Domaine_de_malcor.jpg"
 "317 Espinasse",317,FR,4427.633N,00613.100E,650.0m,3,270,350.0m,,,"270/90 Cultures fouragere attero delicat a partir debut juin. {difficile}",,"317_Espinasse.jpg"
 "318 Montgardin",318,FR,4432.983N,00612.817E,800.0m,3,330,230.0m,,,"330 Atterro face NW. Bumpy. Ne pas utiliser les champs au S. {normal}",,"318_Montgardin.jpg"
-"320 Bayon",320,FR,4420.150N,00609.800E,860.0m,3,215,220.0m,,,"SW/NE Prairie. Reco a pied indispensable. {tres_difficile}",,
+"320 Bayons",320,FR,4420.150N,00609.800E,860.0m,3,215,220.0m,,,"SW/NE Prairie. Reco a pied indispensable. {tres_difficile}",,
 "321 Noyer sur Jabron",321,FR,4410.200N,00550.500E,560.0m,3,340,280.0m,,,"340 uniquement. Reco a pied indispensable. {difficile}",,"321_Noyer_sur_Jabron.jpg"
 "322 Volonne",322,FR,4406.100N,00600.000E,490.0m,3,0,250.0m,,,"ZA Cultures possibles. {facile}",,"322_Volonne.jpg"
 "323 Salignac",323,FR,4408.300N,00558.800E,500.0m,3,160,500.0m,,,"160/340 Cultures. {facile}",,"323_Salignac.jpg"
-"324 Thouard",324,FR,4407.050N,00607.700E,670.0m,3,0,250.0m,,,"ZA Reco a pied indispensable. Cultures possible. {difficile}",,"324_Thouard.jpg"
+"324 Thoard",324,FR,4407.050N,00607.700E,670.0m,3,0,250.0m,,,"ZA Reco a pied indispensable. Cultures possible. {difficile}",,"324_Thouard.jpg"
 "325 Malmoisson",325,FR,4401.800N,00605.000E,460.0m,3,0,300.0m,,,"ZA Cultures possibles. {facile}",,"325_Mallemoisson.jpg"
 "330 Selonnet 1",330_1,FR,4422.100N,00618.600E,1080.0m,3,0,250.0m,,,"ZA Culture possibles. {normal}",,"330_Selonnet.jpg"
 "330 Selonnet 2",330_2,FR,4420.800N,00619.900E,1150.0m,3,0,250.0m,,,"ZA Culture possibles. {normal}",,
@@ -101,7 +101,7 @@ name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc,userdata,pics
 "413 Le Rosier",413,FR,4456.117N,00640.850E,1400.0m,3,180,400.0m,,,"N/S Champ difficile. Fosses buse au milieu du champ. Approche sur le 1er champ et se poser sur le 2. Reco a pied indispensable. {difficile}",,"413_Le_rosier.jpg"
 "420 Roche de Rame",420,FR,4444.600N,00634.500E,920.0m,3,360,150.0m,,,"N/S Tres delicat. Reco a pied indispensable. Beaucoup de fosses. {tres_difficile}",,
 "421 Chateauroux",421,FR,4436.050N,00631.900E,860.0m,3,0,200.0m,,,"ZA Reco a pied indispensable. Ligne THT en cours de construction. {difficile}",,"421_Chateauroux.jpg"
-"422 Les Crots ULM",422,FR,4432.150N,00626.017E,780.0m,3,60,250.0m,,123.5,"060/240 ULM en gravier. Piste non balisee. Largeur 40m. Attention kite surf. {facile}",,"422_Les_crots.jpg"
+"422 Crots ULM",422,FR,4432.150N,00626.017E,780.0m,3,60,250.0m,,123.5,"060/240 ULM en gravier. Piste non balisee. Largeur 40m. Attention kite surf. {facile}",,"422_Les_crots.jpg"
 "423 Pruniere",423,FR,4432.050N,00621.800E,860.0m,3,310,450.0m,,,"310 Vent arriere cote S du champ. Prairie. {facile}",,"423_Prunieres.jpg"
 "510 Saou",510,FR,4438.200N,00503.767E,300.0m,3,0,400.0m,,,"ZA Choisir en fct cultures. {facile}",,
 "511 Die ZA",511,FR,4446.100N,00521.200E,400.0m,3,0,300.0m,,,"ZA Choisir en fct cultures. {facile}",,


### PR DESCRIPTION
corrigé 3 erreurs de toponymie
- Bayons au lieu de Bayon
- Crots au lieu de les Crots
- Thoard au lieu de Thouard